### PR TITLE
Update package versions in project files

### DIFF
--- a/PCAxis.Menu.MsSqlDatamodelMenu.UnitTest/PCAxis.Menu.MsSqlDatamodelMenu.UnitTest.csproj
+++ b/PCAxis.Menu.MsSqlDatamodelMenu.UnitTest/PCAxis.Menu.MsSqlDatamodelMenu.UnitTest.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PCAxis.Menu.MsSqlDatamodelMenu/PCAxis.Menu.MsSqlDatamodelMenu.csproj
+++ b/PCAxis.Menu.MsSqlDatamodelMenu/PCAxis.Menu.MsSqlDatamodelMenu.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PCAxis.Menu" Version="1.0.3" />
+    <PackageReference Include="PCAxis.Menu" Version="1.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Upgraded `MSTest.TestAdapter` and `MSTest.TestFramework` to version 3.9.3 in `PCAxis.Menu.MsSqlDatamodelMenu.UnitTest.csproj`.
- Updated `PCAxis.Menu` package to version 1.0.4 in `PCAxis.Menu.MsSqlDatamodelMenu.csproj`.